### PR TITLE
include target url in pipelines.Pipelines error message

### DIFF
--- a/concourse/api/pipelines.go
+++ b/concourse/api/pipelines.go
@@ -28,17 +28,19 @@ func NewClient(target string) Client {
 }
 
 func (c client) Pipelines() ([]Pipeline, error) {
-	resp, err := http.Get(fmt.Sprintf(
+	targetUrl := fmt.Sprintf(
 		"%s%s/pipelines",
 		c.target,
 		apiPrefix,
-	))
+	)
+	resp, err := http.Get(targetUrl)
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Unexpected response status code: %d, expected: %d",
+		return nil, fmt.Errorf("Unexpected response from  - status code: %d, expected: %d",
+			targetUrl,
 			resp.StatusCode,
 			http.StatusOK,
 		)

--- a/concourse/api/pipelines_test.go
+++ b/concourse/api/pipelines_test.go
@@ -86,5 +86,29 @@ var _ = Describe("Check", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
+		Context("when getting pipelines on invalid target", func() {
+			BeforeEach(func() {
+				server.Reset()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf(
+							"%s/pipelines",
+							apiPrefix,
+						)),
+						ghttp.RespondWith(
+							http.StatusNotFound,
+							"",
+						),
+					),
+				)
+			})
+
+			It("returns error including target url", func() {
+				_, err := client.Pipelines()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring(target))
+			})
+		})
+
 	})
 })


### PR DESCRIPTION
It should be easier to debug when an invalid concourse url is used