### PR TITLE
Update API Client to do Basic Auth

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -68,7 +68,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	apiClient := api.NewClient(input.Source.Target)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	checkCommand := check.NewCheckCommand(version, l, logFile.Name(), flyConn, apiClient)
 	response, err := checkCommand.Run(input)
 	if err != nil {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -75,7 +75,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	apiClient := api.NewClient(input.Source.Target)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	response, err := in.NewInCommand(version, l, flyConn, apiClient, downloadDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -94,7 +94,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	apiClient := api.NewClient(input.Source.Target)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	response, err := out.NewOutCommand(version, l, flyConn, apiClient, sourcesDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/concourse/api/pipelines.go
+++ b/concourse/api/pipelines.go
@@ -19,20 +19,28 @@ type Client interface {
 
 type client struct {
 	target string
+	username string
+	password string
 }
 
-func NewClient(target string) Client {
-	return &client{
-		target: target,
-	}
+func NewClient(target string, username string, password string) Client {
+	return &client{target: target, username: username, password: password}
 }
 
 func (c client) Pipelines() ([]Pipeline, error) {
-	resp, err := http.Get(fmt.Sprintf(
-		"%s%s/pipelines",
-		c.target,
-		apiPrefix,
-	))
+	client := &http.Client{}
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf(
+			"%s%s/pipelines",
+			c.target,
+			apiPrefix,
+		),
+		nil)
+
+	req.SetBasicAuth(c.username, c.password)
+	resp, err := client.Do(req)
+
 	if err != nil {
 		return nil, err
 	}

--- a/concourse/api/pipelines_test.go
+++ b/concourse/api/pipelines_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Check", func() {
 		target = server.URL()
 
 		fakeLogger = &loggerfakes.FakeLogger{}
-		client = api.NewClient(target)
+		client = api.NewClient(target, "", "")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
As mentioned in #1, the API Client was not actually using the provided username and password, instead relying on them to be embedded in the URL.

This changes that behaivor, so the API Client takes username and password in addition to target, and uses them for basic authentication.

