### PR TITLE
Make Source.Target optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ in this repository.
 
 ## Source Configuration
 
-* `target`: *Required.*  URL of your concourse instance e.g. `https://my-concourse.com`.
+* `target`: URL of your concourse instance e.g. `https://my-concourse.com`.
+  If not specified, the resource defaults to the `ATC_EXTERNAL_URL` environment variable.
 
 * `username`: *Required.*  Basic auth username for logging in to Concourse.
   Basic Auth must be enabled on the Concourse installation.

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -68,6 +68,10 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	if input.Source.Target == "" {
+		input.Source.Target = os.Getenv("ATC_EXTERNAL_URL")
+	}
+
 	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	checkCommand := check.NewCheckCommand(version, l, logFile.Name(), flyConn, apiClient)
 	response, err := checkCommand.Run(input)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -75,6 +75,10 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	if input.Source.Target == "" {
+		input.Source.Target = os.Getenv("ATC_EXTERNAL_URL")
+	}
+
 	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	response, err := in.NewInCommand(version, l, flyConn, apiClient, downloadDir).Run(input)
 	if err != nil {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -94,6 +94,10 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	if input.Source.Target == "" {
+		input.Source.Target = os.Getenv("ATC_EXTERNAL_URL")
+	}
+
 	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
 	response, err := out.NewOutCommand(version, l, flyConn, apiClient, sourcesDir).Run(input)
 	if err != nil {

--- a/validator/check_validator.go
+++ b/validator/check_validator.go
@@ -7,10 +7,6 @@ import (
 )
 
 func ValidateCheck(input concourse.CheckRequest) error {
-	if input.Source.Target == "" {
-		return fmt.Errorf("%s must be provided", "target")
-	}
-
 	if input.Source.Username == "" {
 		return fmt.Errorf("%s must be provided", "username")
 	}

--- a/validator/check_validator_test.go
+++ b/validator/check_validator_test.go
@@ -22,19 +22,6 @@ var _ = Describe("ValidateCheck", func() {
 		}
 	})
 
-	Context("when no target is provided", func() {
-		BeforeEach(func() {
-			checkRequest.Source.Target = ""
-		})
-
-		It("returns an error", func() {
-			err := validator.ValidateCheck(checkRequest)
-			Expect(err).To(HaveOccurred())
-
-			Expect(err.Error()).To(MatchRegexp(".*target.*provided"))
-		})
-	})
-
 	Context("when no username is provided", func() {
 		BeforeEach(func() {
 			checkRequest.Source.Username = ""

--- a/validator/in_validator.go
+++ b/validator/in_validator.go
@@ -7,10 +7,6 @@ import (
 )
 
 func ValidateIn(input concourse.InRequest) error {
-	if input.Source.Target == "" {
-		return fmt.Errorf("%s must be provided", "target")
-	}
-
 	if input.Source.Username == "" {
 		return fmt.Errorf("%s must be provided", "username")
 	}

--- a/validator/in_validator_test.go
+++ b/validator/in_validator_test.go
@@ -22,19 +22,6 @@ var _ = Describe("ValidateIn", func() {
 		}
 	})
 
-	Context("when no target is provided", func() {
-		BeforeEach(func() {
-			inRequest.Source.Target = ""
-		})
-
-		It("returns an error", func() {
-			err := validator.ValidateIn(inRequest)
-			Expect(err).To(HaveOccurred())
-
-			Expect(err.Error()).To(MatchRegexp(".*target.*provided"))
-		})
-	})
-
 	Context("when no username is provided", func() {
 		BeforeEach(func() {
 			inRequest.Source.Username = ""

--- a/validator/out_validator.go
+++ b/validator/out_validator.go
@@ -7,10 +7,6 @@ import (
 )
 
 func ValidateOut(input concourse.OutRequest) error {
-	if input.Source.Target == "" {
-		return fmt.Errorf("%s must be provided", "target")
-	}
-
 	if input.Source.Username == "" {
 		return fmt.Errorf("%s must be provided", "username")
 	}

--- a/validator/out_validator_test.go
+++ b/validator/out_validator_test.go
@@ -37,19 +37,6 @@ var _ = Describe("ValidateOut", func() {
 		Expect(validator.ValidateOut(outRequest)).Should(Succeed())
 	})
 
-	Context("when no target is provided", func() {
-		BeforeEach(func() {
-			outRequest.Source.Target = ""
-		})
-
-		It("returns an error", func() {
-			err := validator.ValidateOut(outRequest)
-			Expect(err).To(HaveOccurred())
-
-			Expect(err.Error()).To(MatchRegexp(".*target.*provided"))
-		})
-	})
-
 	Context("when no username is provided", func() {
 		BeforeEach(func() {
 			outRequest.Source.Username = ""


### PR DESCRIPTION
This PR makes specifying a target optional. If one is not provided the resource will default to using the [ATC_EXTERNAL_URL](https://concourse.ci/implementing-resources.html#resource-metadata) environment variable;  

This makes it possible to target the local concourse host without having to know it's location at the time the pipeline is flown.  As you can imagine, this is very helpful in automated environments :)
