### PR TITLE
Use the Insecure setting added in PR #4 when creating the API Client

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/robdimsdale/concourse-pipeline-resource/check"
 	"github.com/robdimsdale/concourse-pipeline-resource/concourse"
@@ -73,7 +74,16 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
+	insecure := false
+	if input.Source.Insecure != "" {
+		var err error
+		insecure, err = strconv.ParseBool(input.Source.Insecure)
+		if err != nil {
+			log.Fatalln("Invalid value for insecure: %v", input.Source.Insecure)
+		}
+	}
+
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, insecure)
 	checkCommand := check.NewCheckCommand(version, l, logFile.Name(), flyConn, apiClient)
 	response, err := checkCommand.Run(input)
 	if err != nil {

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -73,7 +73,7 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
 	checkCommand := check.NewCheckCommand(version, l, logFile.Name(), flyConn, apiClient)
 	response, err := checkCommand.Run(input)
 	if err != nil {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -80,7 +80,7 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
 	response, err := in.NewInCommand(version, l, flyConn, apiClient, downloadDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/robdimsdale/concourse-pipeline-resource/concourse"
 	"github.com/robdimsdale/concourse-pipeline-resource/concourse/api"
@@ -80,7 +81,16 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
+	insecure := false
+	if input.Source.Insecure != "" {
+		var err error
+		insecure, err = strconv.ParseBool(input.Source.Insecure)
+		if err != nil {
+			log.Fatalln("Invalid value for insecure: %v", input.Source.Insecure)
+		}
+	}
+
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, insecure)
 	response, err := in.NewInCommand(version, l, flyConn, apiClient, downloadDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -99,7 +99,7 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password)
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
 	response, err := out.NewOutCommand(version, l, flyConn, apiClient, sourcesDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/robdimsdale/concourse-pipeline-resource/cmd/out/filereader"
 	"github.com/robdimsdale/concourse-pipeline-resource/concourse"
@@ -99,7 +100,16 @@ func main() {
 		input.Source.Target = os.Getenv(atcExternalURLEnvKey)
 	}
 
-	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, input.Source.Insecure)
+	insecure := false
+	if input.Source.Insecure != "" {
+		var err error
+		insecure, err = strconv.ParseBool(input.Source.Insecure)
+		if err != nil {
+			log.Fatalln("Invalid value for insecure: %v", input.Source.Insecure)
+		}
+	}
+
+	apiClient := api.NewClient(input.Source.Target, input.Source.Username, input.Source.Password, insecure)
 	response, err := out.NewOutCommand(version, l, flyConn, apiClient, sourcesDir).Run(input)
 	if err != nil {
 		l.Debugf("Exiting with error: %v\n", err)

--- a/concourse/api/pipelines.go
+++ b/concourse/api/pipelines.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"strconv"
 )
 
 const (
@@ -24,10 +22,10 @@ type client struct {
 	target   string
 	username string
 	password string
-	insecure string
+	insecure bool
 }
 
-func NewClient(target string, username string, password string, insecure string) Client {
+func NewClient(target string, username string, password string, insecure bool) Client {
 	return &client{target: target, username: username, password: password, insecure: insecure}
 }
 
@@ -38,18 +36,9 @@ func (c client) Pipelines() ([]Pipeline, error) {
 		apiPrefix,
 	)
 
-	insecure := false
-	if c.insecure != "" {
-		var err error
-		insecure, err = strconv.ParseBool(c.insecure)
-		if err != nil {
-			log.Fatalln("Invalid value for insecure: %v", c.insecure)
-		}
-	}
-
 	client := &http.Client{}
 
-	if insecure {
+	if c.insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			Proxy:           http.ProxyFromEnvironment,

--- a/concourse/api/pipelines_test.go
+++ b/concourse/api/pipelines_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Check", func() {
 		target = server.URL()
 
 		fakeLogger = &loggerfakes.FakeLogger{}
-		client = api.NewClient(target, "", "")
+		client = api.NewClient(target, "", "", "")
 	})
 
 	AfterEach(func() {

--- a/concourse/api/pipelines_test.go
+++ b/concourse/api/pipelines_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Check", func() {
 		target = server.URL()
 
 		fakeLogger = &loggerfakes.FakeLogger{}
-		client = api.NewClient(target, "", "", "")
+		client = api.NewClient(target, "", "", false)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
One more PR from me today :)

While testing the new insecure setting, I noticed it doesn't seem to work, as the API Client wasn't looking at that setting, so API calls would cause a failure before fly is ever executed.
